### PR TITLE
Multiple small changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "liblrs"
 version = "0.1.0"
 edition = "2021"
+description = "Library to manipulate linear referencing systems"
+license = "MIT"
 
 [workspace]
 members = ["wasm", "python"]
@@ -22,4 +24,4 @@ geo = "0.28"
 thiserror = "1.0"
 osm4routing = "0.6.4"
 clap = { version = "4.5.1", features = ["derive"] }
-num-traits = "*"
+num-traits = "0.2"

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,8 +1,8 @@
 //! High level extensions meant for an easy usage
 //! Those functions are exposed in wasm-bindings
 
-use liblrs::builder::Properties;
 use liblrs::lrs_ext::*;
+use liblrs::{builder::Properties, lrs::LrsBase};
 use pyo3::{exceptions::PyTypeError, prelude::*};
 
 /// Holds the whole Linear Referencing System.
@@ -252,7 +252,16 @@ impl Lrs {
             .map_err(|e| PyTypeError::new_err(e.to_string()))
     }
 
-    /// Given two [`LrmScaleMeasure`]s, return a range of [`LineString`].
+    /// Get the positon along the curve given a [`LrmScaleMeasure`]
+    /// The value will be between 0.0 and 1.0, both included
+    pub fn locate_point(&self, lrm_index: usize, measure: &LrmScaleMeasure) -> PyResult<f64> {
+        self.lrs.lrs.lrms[lrm_index]
+            .scale
+            .locate_point(&measure.into())
+            .map_err(|e| PyTypeError::new_err(e.to_string()))
+    }
+
+    /// Given two [`LrmScaleMeasure`]s, return a range of [`Point`] that represent a line string.
     pub fn resolve_range(
         &self,
         lrm_index: usize,
@@ -263,6 +272,11 @@ impl Lrs {
             .resolve_range(lrm_index, &from.into(), &to.into())
             .map(|coords| coords.into_iter().map(|coord| coord.into()).collect())
             .map_err(|e| PyTypeError::new_err(e.to_string()))
+    }
+
+    /// Given a ID returns the corresponding lrs index (or None if not found)
+    pub fn find_lrm(&self, lrm_id: &str) -> Option<usize> {
+        self.lrs.lrs.get_lrm(lrm_id).map(|handle| handle.0)
     }
 }
 
@@ -293,6 +307,18 @@ impl Builder {
         name: Option<&str>,
     ) -> usize {
         self.inner.add_anchor(id, name, coord.into(), properties)
+    }
+
+    #[pyo3(signature = (id, position_on_curve, properties, name=None))]
+    pub fn add_projected_anchor(
+        &mut self,
+        id: &str,
+        position_on_curve: f64,
+        properties: Properties,
+        name: Option<&str>,
+    ) -> usize {
+        self.inner
+            .add_projected_anchor(id, name, position_on_curve, properties)
     }
 
     pub fn add_segment(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -350,6 +350,24 @@ impl Builder {
             .add_lrm_with_distances(id, traversal_index, &anchors, properties)
     }
 
+    pub fn add_lrm_with_distances_with_orientation(
+        &mut self,
+        id: &str,
+        traversal_index: usize,
+        reference_traversal_index: usize,
+        anchors: Vec<AnchorOnLrm>,
+        properties: Properties,
+    ) {
+        let anchors: Vec<_> = anchors.into_iter().map(|anchor| anchor.into()).collect();
+        self.inner.add_lrm_with_distances_with_orientation(
+            id,
+            traversal_index,
+            reference_traversal_index,
+            &anchors,
+            properties,
+        )
+    }
+
     pub fn get_traversal_indexes(&mut self) -> std::collections::HashMap<String, usize> {
         self.inner.get_traversal_indexes()
     }
@@ -367,5 +385,9 @@ impl Builder {
 
     pub fn save(&mut self, out_file: String, properties: Properties) {
         self.inner.save(&out_file, properties)
+    }
+
+    pub fn euclidean_distance(&self, lrm_index_a: usize, lrm_index_b: usize) -> f64 {
+        self.inner.euclidean_distance(lrm_index_a, lrm_index_b)
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -187,7 +187,7 @@ pub struct Anchor {
     pub name: String,
     /// Projected position on the [`Curve`] (the reference point isn’t always on the curve).
     #[pyo3(get, set)]
-    pub position: Point,
+    pub position: Option<Point>,
     /// Position on the [`Curve`].
     #[pyo3(get, set)]
     pub curve_position: f64,
@@ -200,7 +200,7 @@ impl From<&liblrs::lrm_scale::Anchor> for Anchor {
     fn from(value: &liblrs::lrm_scale::Anchor) -> Self {
         Self {
             name: value.clone().id.unwrap_or_else(|| "-".to_owned()),
-            position: value.point.into(),
+            position: value.point.map(|p| p.into()),
             curve_position: value.curve_position,
             scale_position: value.scale_position,
         }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -284,12 +284,13 @@ impl Builder {
         self.inner.add_node(id, properties)
     }
 
+    #[pyo3(signature = (id, coord, properties, name=None))]
     pub fn add_anchor(
         &mut self,
         id: &str,
-        name: &str,
         coord: Point,
         properties: Properties,
+        name: Option<&str>,
     ) -> usize {
         self.inner.add_anchor(id, name, coord.into(), properties)
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -115,11 +115,11 @@ impl<'fbb> Builder<'fbb> {
         self.nodes.len() - 1
     }
 
-    /// Add a new [`Anchor`].
+    /// Add a new [`Anchor`] based on the coordinates.
     pub fn add_anchor(
         &mut self,
         id: &str,
-        name: &str,
+        name: Option<&str>,
         coord: Coord,
         properties: Properties,
     ) -> usize {
@@ -127,7 +127,7 @@ impl<'fbb> Builder<'fbb> {
         let geometry = Point::new(coord.x, coord.y);
         let anchor_arg = AnchorArgs {
             id: Some(self.fbb.create_string(id)),
-            name: Some(self.fbb.create_string(name)),
+            name: name.map(|n| self.fbb.create_string(n)),
             geometry: Some(&geometry),
             properties,
             ..Default::default()

--- a/src/curves.rs
+++ b/src/curves.rs
@@ -59,6 +59,9 @@ pub trait Curve {
 
     /// Get a range of the `Curve`
     fn sublinestring(&self, from: f64, to: f64) -> Option<LineString>;
+
+    /// Reverses the direction of the `Curve`
+    fn reverse(&mut self);
 }
 
 /// Errors when manipulating the [`Curve`]s.
@@ -263,6 +266,12 @@ impl Curve for PlanarLineStringCurve {
         } else {
             None
         }
+    }
+
+    fn reverse(&mut self) {
+        let mut points = self.geom.clone().into_inner();
+        points.reverse();
+        self.geom = LineString::new(points);
     }
 }
 
@@ -523,10 +532,16 @@ impl Curve for SphericalLineStringCurve {
             None
         }
     }
+
+    fn reverse(&mut self) {
+        let mut points = self.geom.clone().into_inner();
+        points.reverse();
+        self.geom = LineString::new(points);
+    }
 }
 
 /// Represents a [`Point`] in space projected on the [`Curve`].
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct CurveProjection {
     /// How far from the [`Curve`] start is located the [`Point`].
     pub distance_along_curve: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ fn read_and_write_lrs() {
     let mut builder = Builder::new();
     let anchor_index = builder.add_anchor(
         "Ancre",
-        "12",
+        Some("12"),
         Coord { x: 0., y: 0. },
         properties!("some key" => "some value"),
     );

--- a/src/lrm_scale.rs
+++ b/src/lrm_scale.rs
@@ -127,6 +127,7 @@ pub struct LrmScale {
 impl LrmScale {
     /// Locates a point along a `Curve` given an [Anchor] and an `offset`,
     /// which might be negative.
+    /// The `[CurvePosition]` is between 0.0 and 1.0, both included
     pub fn locate_point(&self, measure: &LrmScaleMeasure) -> Result<CurvePosition, LrmScaleError> {
         let named_anchor = self
             .iter_named()
@@ -268,17 +269,17 @@ pub mod tests {
         // Everything a usual
         assert_eq!(
             scale().locate_point(&LrmScaleMeasure::new("a", 5.)),
-            Ok(50.)
+            Ok(0.25)
         );
         assert_eq!(
             scale().locate_point(&LrmScaleMeasure::new("b", 5.)),
-            Ok(150.)
+            Ok(0.75)
         );
 
         // Negative offsets
         assert_eq!(
             scale().locate_point(&LrmScaleMeasure::new("a", -5.)),
-            Ok(-50.)
+            Ok(-0.25)
         );
 
         // Unknown Anchor
@@ -306,15 +307,15 @@ pub mod tests {
 
     #[test]
     fn locate_anchor() {
-        let measure = scale().locate_anchor(40.).unwrap();
+        let measure = scale().locate_anchor(0.2).unwrap();
         assert_eq!(measure.anchor_name, "a");
         assert_eq!(measure.scale_offset, 4.);
 
-        let measure = scale().locate_anchor(150.).unwrap();
+        let measure = scale().locate_anchor(0.75).unwrap();
         assert_eq!(measure.anchor_name, "b");
         assert_eq!(measure.scale_offset, 5.);
 
-        let measure = scale().locate_anchor(-10.).unwrap();
+        let measure = scale().locate_anchor(-0.05).unwrap();
         assert_eq!(measure.anchor_name, "a");
         assert_eq!(measure.scale_offset, -1.);
     }

--- a/src/lrm_scale.rs
+++ b/src/lrm_scale.rs
@@ -43,7 +43,7 @@ pub struct Anchor {
     pub curve_position: CurvePosition,
 
     /// Position of the anchor on the `Curve`.
-    pub point: Point,
+    pub point: Option<Point>,
 }
 
 impl Anchor {
@@ -52,7 +52,7 @@ impl Anchor {
         name: &str,
         scale_position: ScalePosition,
         curve_position: CurvePosition,
-        point: Point,
+        point: Option<Point>,
     ) -> Self {
         Self {
             id: Some(name.to_owned()),
@@ -66,7 +66,7 @@ impl Anchor {
     pub fn new_unnamed(
         scale_position: ScalePosition,
         curve_position: CurvePosition,
-        point: Point,
+        point: Option<Point>,
     ) -> Self {
         Self {
             id: None,
@@ -258,8 +258,8 @@ pub mod tests {
         LrmScale {
             id: "id".to_owned(),
             anchors: vec![
-                Anchor::new("a", 0., 0., point! { x: 0., y: 0. }),
-                Anchor::new("b", 10., 100., point! { x: 0., y: 0. }),
+                Anchor::new("a", 0., 0., Some(point! { x: 0., y: 0. })),
+                Anchor::new("b", 10., 0.5, Some(point! { x: 0., y: 0. })),
             ],
         }
     }
@@ -294,8 +294,8 @@ pub mod tests {
         let scale = LrmScale {
             id: "id".to_owned(),
             anchors: vec![
-                Anchor::new("a", 0., 2., point! { x: 0., y: 0. }),
-                Anchor::new("b", 10., 3., point! { x: 0., y: 0. }),
+                Anchor::new("a", 0., 2., Some(point! { x: 0., y: 0. })),
+                Anchor::new("b", 10., 3., Some(point! { x: 0., y: 0. })),
             ],
         };
 
@@ -326,10 +326,10 @@ pub mod tests {
         let scale = LrmScale {
             id: "id".to_owned(),
             anchors: vec![
-                Anchor::new_unnamed(0., 100., point! { x: 0., y: 0. }),
-                Anchor::new("a", 1., 200., point! { x: 0., y: 0. }),
-                Anchor::new("b", 3., 300., point! { x: 0., y: 0. }),
-                Anchor::new_unnamed(4., 400., point! { x: 0., y: 0. }),
+                Anchor::new_unnamed(0., 100., Some(point! { x: 0., y: 0. })),
+                Anchor::new("a", 1., 200., Some(point! { x: 0., y: 0. })),
+                Anchor::new("b", 3., 300., Some(point! { x: 0., y: 0. })),
+                Anchor::new_unnamed(4., 400., Some(point! { x: 0., y: 0. })),
             ],
         };
 

--- a/src/lrm_scale.rs
+++ b/src/lrm_scale.rs
@@ -387,4 +387,28 @@ pub mod tests {
             .unwrap();
         assert_eq!(position, 25.);
     }
+
+    #[test]
+    fn single_anchor() {
+        // Scenario where the curve is to short to have an anchor
+        // The scale of the curve goes from 1200 to 1300
+        // The anchor corresponding to the 0 of the scale is at -2. of the curve
+        // Anchor(curve: -2, scale: 1000)    [curve begin]------Unamed(curve: 0, scale: 1300)
+        let scale = LrmScale {
+            id: "id".to_owned(),
+            anchors: vec![
+                Anchor::new("a", 1000. + 0., -2., None),
+                Anchor::new_unnamed(1000. + 300., 1., None),
+            ],
+        };
+
+        let position = scale
+            .locate_point(&LrmScaleMeasure {
+                anchor_name: "a".to_string(),
+                scale_offset: 200.,
+            })
+            .unwrap();
+
+        assert_eq!(position, 0.);
+    }
 }

--- a/src/lrs.rs
+++ b/src/lrs.rs
@@ -131,14 +131,14 @@ pub struct LrmRange {
 }
 
 /// Helper to project an [`Anchor`] on a [`Curve`].
-fn project<CurveImpl: Curve>(anchor: &lrs_generated::Anchor, curve: &CurveImpl) -> (f64, Point) {
-    let p = anchor
-        .geometry()
-        .map(|p| point! {x: p.x(), y: p.y()})
-        .expect("Anchor without geometry");
+fn project<CurveImpl: Curve>(
+    anchor: &lrs_generated::Anchor,
+    curve: &CurveImpl,
+) -> (f64, Option<Point>) {
+    let p = anchor.geometry().map(|p| point! {x: p.x(), y: p.y()});
 
     let distance_along_curve = curve
-        .project(p)
+        .project(p.unwrap())
         .expect("Could not project anchor on the curve")
         .distance_along_curve;
 
@@ -218,12 +218,13 @@ impl<CurveImpl: Curve> Lrs<CurveImpl> {
                         .projected_anchors()
                         .map(|anchors| {
                             let projected_anchor = anchors.get(idx);
-                            let geometry = projected_anchor.geometry().unwrap();
-                            let point = point! {
-                                x: geometry.x(),
-                                y: geometry.y(),
-                            };
-                            (projected_anchor.distance_along_curve(), point)
+                            let geometry = projected_anchor.geometry().map(|geom| {
+                                point! {
+                                    x: geom.x(),
+                                    y: geom.y(),
+                                }
+                            });
+                            (projected_anchor.distance_along_curve(), geometry)
                         })
                         .unwrap_or_else(|| project(&anchor, curve));
 

--- a/src/lrs_ext.rs
+++ b/src/lrs_ext.rs
@@ -54,7 +54,7 @@ impl ExtLrs {
         let curve_position = lrm.scale.locate_point(measure)?;
 
         let traversal_position = TraversalPosition {
-            distance_from_start: curve_position,
+            curve_position,
             traversal: lrm.reference_traversal,
         };
         self.lrs.locate_traversal(traversal_position)
@@ -73,7 +73,7 @@ impl ExtLrs {
         let from = scale.locate_point(from).map_err(|e| e.to_string())?;
         let to = scale.locate_point(to).map_err(|e| e.to_string())?;
 
-        match curve.sublinestring(from / curve.length(), to / curve.length()) {
+        match curve.sublinestring(from, to) {
             Some(linestring) => Ok(linestring.0),
             None => Err("Could not find sublinestring".to_string()),
         }

--- a/src/lrs_ext.rs
+++ b/src/lrs_ext.rs
@@ -51,7 +51,7 @@ impl ExtLrs {
     /// Get the position given a [`LrmScaleMeasure`].
     pub fn resolve(&self, lrm_index: usize, measure: &LrmScaleMeasure) -> Result<Point, LrsError> {
         let lrm = &self.lrs.lrms[lrm_index];
-        let curve_position = lrm.scale.locate_point(measure)?;
+        let curve_position = lrm.scale.locate_point(measure)?.clamp(0., 1.0);
 
         let traversal_position = TraversalPosition {
             curve_position,
@@ -70,8 +70,14 @@ impl ExtLrs {
         let lrm = &self.lrs.lrms[lrm_index];
         let scale = &lrm.scale;
         let curve = &self.lrs.traversals[lrm.reference_traversal.0].curve;
-        let from = scale.locate_point(from).map_err(|e| e.to_string())?;
-        let to = scale.locate_point(to).map_err(|e| e.to_string())?;
+        let from = scale
+            .locate_point(from)
+            .map_err(|e| e.to_string())?
+            .clamp(0., 1.);
+        let to = scale
+            .locate_point(to)
+            .map_err(|e| e.to_string())?
+            .clamp(0., 1.);
 
         match curve.sublinestring(from, to) {
             Some(linestring) => Ok(linestring.0),

--- a/src/lrs_ext.rs
+++ b/src/lrs_ext.rs
@@ -13,7 +13,8 @@ type Lrs = lrs::Lrs<SphericalLineStringCurve>;
 
 /// Struct exposed to js.
 pub struct ExtLrs {
-    lrs: Lrs,
+    /// The linear referencing system
+    pub lrs: Lrs,
 }
 
 impl ExtLrs {

--- a/src/osm_helpers.rs
+++ b/src/osm_helpers.rs
@@ -98,11 +98,7 @@ pub fn sort_edges(edges: Vec<Edge>, traversal_ref: &str) -> Vec<(Edge, bool)> {
         } else {
             last_edge.0.target
         };
-        println!("[WARN] on traversal {traversal_ref}, ignoring {ignored} edges out of {total}");
-        println!(
-            "       Sorted traversal from osm node: {} to: {}",
-            first.0, last.0
-        );
+        println!("[WARN] on traversal {traversal_ref}, ignoring {ignored} edges out of {total}. Sorted from {} to {}", first.0, last.0);
     }
 
     sorted

--- a/wasm/html_demo/index.js
+++ b/wasm/html_demo/index.js
@@ -29,7 +29,9 @@ async function file_selected(el) {
 
         for (const anchor of anchors) {
             const properties = { id: anchor.name, lrm_id, curve: anchor.curve_position, scale: anchor.scale_position }
-            anchors_features.push(turf.point([anchor.position.x, anchor.position.y], properties, { id: anchors_features.length }))
+            if (anchor.position) {
+                anchors_features.push(turf.point([anchor.position.x, anchor.position.y], properties, { id: anchors_features.length }))
+            }
         }
     }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -84,7 +84,7 @@ pub struct Anchor {
     /// `name` of the [`Anchor`].
     pub name: String,
     /// Projected position on the [`Curve`] (the reference point isn’t always on the curve).
-    pub position: Point,
+    pub position: Option<Point>,
     /// Position on the [`Curve`].
     pub curve_position: f64,
     /// Position on the scale.
@@ -95,7 +95,7 @@ impl From<&liblrs::lrm_scale::Anchor> for Anchor {
     fn from(value: &liblrs::lrm_scale::Anchor) -> Self {
         Self {
             name: value.clone().id.unwrap_or_else(|| "-".to_owned()),
-            position: value.point.into(),
+            position: value.point.map(|p| p.into()),
             curve_position: value.curve_position,
             scale_position: value.scale_position,
         }


### PR DESCRIPTION
- The position on the curve is [0,1]. This reduces ambiguity about the unit used, and simplifies mental model
- Name of anchors are optional: allows to set the end of curve to allow computations when there is only one anchor
- Coordinates of anchors are optional: allows to handle #15 by creating virtual anchors
- Minor stuff (metadata, verbosity)

Closes #15 