### PR TITLE
Improvements on python packaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "liblrs_python"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "geo-types",
  "liblrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "liblrs_python"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "geo-types",
  "liblrs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.1"
 edition = "2021"
 description = "Library to manipulate linear referencing systems"
 license = "MIT"
+homepage = "https://github.com/osrd-project/liblrs/"
 
 [workspace]
 members = ["wasm", "python"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "liblrs_python"
+description = "Python bindings for liblrs: a library to work with linear referencing systems"
 version = "0.1.5"
 edition = "2021"
+license = "MIT"
+repository = "https://github.com/osrd-project/liblrs/"
 
 [lib]
 crate-type = ["cdylib"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,4 +12,5 @@ crate-type = ["cdylib"]
 [dependencies]
 liblrs = { path = ".." }
 geo-types = "*"
-pyo3 = { version = "0.22.1", features = ["extension-module"]}
+# "abi3-py38" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.8
+pyo3 = { version = "0.22.1", features = ["abi3-py38"]}

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "liblrs_python"
 description = "Python bindings for liblrs: a library to work with linear referencing systems"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/osrd-project/liblrs/"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,3 +5,9 @@ build-backend = "maturin"
 [tool.maturin]
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 features = ["pyo3/extension-module"]
+# When building a source distribution with `maturin sdist`, the tarball is meant to be built from the root
+# A user building from source will use maturin, but it won’t find the .pyi file and it won’t be available
+# That is why we add it explicitely when using sdist
+include = [{ path = "liblrs_python.pyi", format = "sdist" }]
+# Avoid a collision with the README.md at the root of the directory
+exclude = [{path = "README.md", format = "sdist"}]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,3 +11,5 @@ features = ["pyo3/extension-module"]
 include = [{ path = "liblrs_python.pyi", format = "sdist" }]
 # Avoid a collision with the README.md at the root of the directory
 exclude = [{path = "README.md", format = "sdist"}]
+# Reduce the binary size (from 8.9 to 1.4 when tested)
+strip = true


### PR DESCRIPTION
When binary: smaller size and better compatibility (on linux)
When source: have the .pyi stubs

How to test:

- create a virtualenv to test
- build a sdist tarball: `cd python && maturin sdist`. It will return the path to the tarball
- build+install the tarball with `pip install path_to/liblrs_python-0.1.7.tar.gz`
- check that in the virtualenv (path similar to `your_venv/lib/python3.12/site-packages/liblrs_python/` you have `__init__.py`