### PR TITLE
pages: add a style token for a nicer map

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,8 @@ jobs:
         run: npm install
       - name: Build the demonstration app
         run: npm run build
+        env:
+          MAPLIBRE_STYLE: ${{ secrets.MAPLIBRE_STYLE }}
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
       - name: Upload GitHub Pages artifact


### PR DESCRIPTION
The token has been added to https://github.com/osrd-project/liblrs/settings/secrets/actions for the environment github-pages

The goal is that when doing `npm build` the environment variable `MAPLIBRE_STYLE` is set