### PR TITLE
wasm: publish releases on npm

### DIFF
--- a/.github/workflows/publish_npm.yaml
+++ b/.github/workflows/publish_npm.yaml
@@ -1,0 +1,22 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@osrd-project'
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/wasm/package.json
+++ b/wasm/package.json
@@ -19,5 +19,11 @@
         "alpinejs": "^3.14.0",
         "maplibre-gl": "^4.3.0",
         "pmtiles": "^3.0.5"
+    },
+    "name": "liblrs",
+    "version": "0.1.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/osrd-project/liblrs/"
     }
 }


### PR DESCRIPTION
I tried to follow: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages
